### PR TITLE
Update indicator padding calc

### DIFF
--- a/lib/src/tile.dart
+++ b/lib/src/tile.dart
@@ -237,9 +237,9 @@ class _Indicator extends StatelessWidget {
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           final indicatorY = constraints.maxHeight * indicatorStyle.indicatorY;
-          final topPadding = indicatorY - (indicatorStyle.height / 2);
-          final bottomPadding = (constraints.maxHeight - indicatorY) -
-              (indicatorStyle.height / 2);
+          final topPadding = indicatorY - indicatorStyle.height;
+          final bottomPadding =
+              constraints.maxHeight - indicatorY - indicatorStyle.height;
 
           return Padding(
             padding: EdgeInsets.only(


### PR DESCRIPTION
Indicator padding issue, Indicator size gets smaller as it gets closer to the edge.

*Example*
```dart
indicatorStyle: IndicatorStyle(
        width: 30,
        height: 30,
        indicatorY: 0~1.0
...
```

| indicatorY | image |
|---|:---:|
|0|![스크린샷 2020-08-02 오후 5 46 52](https://user-images.githubusercontent.com/35303552/89119352-e6ecc800-d4e8-11ea-89d8-6e91abdd10b1.png)|
|0.5|![스크린샷 2020-08-02 오후 5 47 20](https://user-images.githubusercontent.com/35303552/89119368-0c79d180-d4e9-11ea-9d6b-8c51b0a84263.png)|
|1|![스크린샷 2020-08-02 오후 5 47 33](https://user-images.githubusercontent.com/35303552/89119380-1d2a4780-d4e9-11ea-9ef2-86b5ed191311.png)|