### PR TITLE
Removing the author tag and adding issue_tracker

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: timeline_tile
 description: A package to help you build highly customisable timelines with Flutter.
 version: 1.0.0
-author: Julio Bitencourt <julio.henrique.b@gmail.com>
 repository: https://github.com/JHBitencourt/timeline_tile
 homepage: https://github.com/JHBitencourt/timeline_tile
+issue_tracker: https://github.com/JHBitencourt/timeline_tile/issues
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Due to warning:
Your `pubspec.yaml` includes an "author" section which is no longer used and may be removed