### PR TITLE
Changing back the dependency to hosted

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -250,9 +250,9 @@ packages:
   timeline_tile:
     dependency: "direct main"
     description:
-      path: ".."
-      relative: true
-    source: path
+      name: timeline_tile
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,9 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  timeline_tile:
-    path: ../
-
+  timeline_tile: ^1.0.0
   google_fonts: ^1.1.0
   flutter_highlight: ^0.6.0
 


### PR DESCRIPTION
With a path dependency, the project beautiful_timelines can't use the example project as dependency.